### PR TITLE
add exhaustive layout search

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,24 @@
+import unittest
+
+import numpy as np
+
+import solver
+
+
+class TestExhaustiveProb(unittest.TestCase):
+
+    def test_invalid(self):
+        board = np.zeros((1, 2))
+        self.assertIsNone(solver.permutate_board(board, {1: 2}))
+
+    def test_basic(self):
+        board = np.zeros((1, 3))
+        self.assertEqual(solver.permutate_board(board, {1: 2}).all(), np.array([2,0,2]).all())
+
+    def test_example(self):
+        board = np.zeros((3, 3))
+        self.assertEqual(solver.permutate_board(board, {3: 1, 1: 2}).all(), np.array([2,0,2]).all())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add an option to do an exhaustive layout search for the given board.

This is very compute-intensive, so it's recommended to only enable it mid to late game.

Future optimizations are possible, this is just a basic implementation. See issue #1 for discussion.